### PR TITLE
Paste Pokémon feature

### DIFF
--- a/include/pkbank.hpp
+++ b/include/pkbank.hpp
@@ -207,6 +207,8 @@ class PKBank
 		void getPkm(uint16_t boxId, uint16_t rowId, uint16_t colId, pkm_t** pkm, bool inBank = false);
 		void movePkm(pkm_t* src, pkm_t* dest);
 		void movePkm(pkm_t* src, pkm_t* dst, bool srcBanked, bool dstBanked);
+		void pastePkm(pkm_t* src, pkm_t* dest);
+		void pastePkm(pkm_t* src, pkm_t* dst, bool srcBanked, bool dstBanked);
 		void moveBox(uint16_t boxID_1, bool inBank_1, uint16_t boxID_2, bool inBank_2);
 		void addDex(uint16_t speciesID);
 		void addDex(pkm_t* pkm);

--- a/include/viewer/box_viewer.hpp
+++ b/include/viewer/box_viewer.hpp
@@ -57,6 +57,7 @@ class BoxViewer : public Viewer
 		void selectViewPokemon();
 		void selectMovePokemon();
 		void cancelMovePokemon();
+		void pasteMovePokemon();
 };
 
 

--- a/source/pkbank.cpp
+++ b/source/pkbank.cpp
@@ -414,6 +414,32 @@ void PKBank::movePkm(pkm_t* src, pkm_t* dst, bool srcBanked, bool dstBanked)
 
 
 // ==================================================
+void PKBank::pastePkm(pkm_t* src, pkm_t* dst)
+// --------------------------------------------------
+{
+	dst->pk6 = src->pk6;
+
+	loadPkmPk6(dst);
+}
+
+
+// ==================================================
+void PKBank::pastePkm(pkm_t* src, pkm_t* dst, bool srcBanked, bool dstBanked)
+// --------------------------------------------------
+{
+	pastePkm(src, dst);
+
+	if (gametype == Game::ORAS)
+	{
+		if (!srcBanked)
+			addDex(dst);
+		if (!dstBanked)
+			addDex(src);
+	}
+}
+
+
+// ==================================================
 void PKBank::moveBox(uint16_t boxID_1, bool inBank_1, uint16_t boxID_2, bool inBank_2)
 // --------------------------------------------------
 {

--- a/source/viewer/box_viewer.cpp
+++ b/source/viewer/box_viewer.cpp
@@ -354,11 +354,6 @@ Result BoxViewer::updateControls(const u32& kDown, const u32& kHeld, const u32& 
 		switchCursorType();
 	}
 
-	if (kDown & KEY_X)
-	{
-		printf("\x1b[2J");
-	}
-
 	if (cursorType == CursorType::SingleSelect)
 	{
 		if (kDown & KEY_A)
@@ -379,6 +374,11 @@ Result BoxViewer::updateControls(const u32& kDown, const u32& kHeld, const u32& 
 				PHBank::pKBank()->printPkm(vPkm, 0, PK6_SIZE);
 			}
 		}
+
+		if (kDown & KEY_X)
+		{
+			pasteMovePokemon();
+		}
 	}
 	else if (cursorType == CursorType::QuickSelect)
 	{
@@ -398,6 +398,11 @@ Result BoxViewer::updateControls(const u32& kDown, const u32& kHeld, const u32& 
 			{
 				PHBank::pKBank()->moveBox(cursorBox.boxPC, false, cursorBox.boxBK, true);
 			}
+		}
+
+		if (kDown & KEY_X)
+		{
+			pasteMovePokemon();
 		}
 	}
 	else if (cursorType == CursorType::MultipleSelect)
@@ -539,4 +544,19 @@ void BoxViewer::cancelMovePokemon()
 // --------------------------------------------------
 {
 	sPkm = NULL;
+}
+
+
+// --------------------------------------------------
+void BoxViewer::pasteMovePokemon()
+// --------------------------------------------------
+{
+	computeSlot(&cursorBox);
+
+	if (sPkm && vPkm && PHBank::pKBank()->isPkmEmpty(vPkm))
+	{
+		PHBank::pKBank()->pastePkm(sPkm, vPkm, false, cursorBox.inBank);
+	}
+
+	// printf("Pasted Pokemon: [@%p]\n", sPkm);
 }


### PR DESCRIPTION
I just develop a new feature `copy -> multi-paste`

When a Pokémon is selected, you can paste him by cliking `X` (single or quick mode) to duplicate the Pokémon in an empty slot!

:warning: It's impossible to paste over an existing Pokémon to avoid mistake...
