### PR TITLE
Fix broken reference to PKData::HPTypes

### DIFF
--- a/source/pkdata.cpp
+++ b/source/pkdata.cpp
@@ -116,7 +116,7 @@ const char hpTypes[16][9] = {
 };
 
 // --------------------------------------------------
-const char* HPTypes(u8 hiddenPower)
+const char* PKData::HPTypes(u8 hiddenPower)
 // --------------------------------------------------
 {
 	if (hiddenPower < 16)


### PR DESCRIPTION
This commit is broken https://github.com/gocario/PHBank/commit/843478cc07b3a1675214e3ecc1ffdb872ce441c1#diff-67c4c6f6c9d4e5442d5858d4dfc500d1R119
