### PR TITLE
Show gender icon of selected Pokémon.

### DIFF
--- a/source/viewer/box_viewer.cpp
+++ b/source/viewer/box_viewer.cpp
@@ -311,6 +311,16 @@ Result BoxViewer::drawTopScreen()
 		sf2d_draw_texture_part(PHBanku::texture->boxTiles, 320 ,135, 9*3, 64 + 9*vPkm.heart, 9, 9);
 		sf2d_draw_texture_part(PHBanku::texture->boxTiles, 330 ,135, 9*4, 64 + 9*vPkm.star, 9, 9);
 		sf2d_draw_texture_part(PHBanku::texture->boxTiles, 340 ,135, 9*5, 64 + 9*vPkm.diamond, 9, 9);
+
+		switch (Pokemon::gender(pkm))
+		{
+			case 0: // Male
+				sf2d_draw_texture_part(PHBanku::texture->boxTiles, 385, 130, 60, 82, 12, 12);
+				break;
+			case 1: // Female
+				sf2d_draw_texture_part(PHBanku::texture->boxTiles, 388, 130, 72, 82, 12, 12);
+				break;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
Show gender icon on the bottom right corner of the sprite (not sure if it's a good place, but it looks nice enough for me. Change as needed).

http://imgur.com/a/eSmkC

Tested and working (managed to build it!).
